### PR TITLE
Remove powermock (WIP)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -350,20 +350,5 @@
       <artifactId>commons-pool2</artifactId>
       <version>2.6.0</version>
     </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-api-mockito</artifactId>
-      <version>1.7.4</version>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-core</artifactId>
-      <version>1.7.4</version>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-module-junit4</artifactId>
-      <version>2.0.2</version>
-    </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
Opening PR, as Issues are disabled on this repo.

We should try to replace Mockito with direct instantiation in non-test code.
It breaks projects depending on this library, as Powermock doesn't get loaded correctly.